### PR TITLE
Fix detection of first sheet.

### DIFF
--- a/xlsx_streaming/streaming.py
+++ b/xlsx_streaming/streaming.py
@@ -116,6 +116,10 @@ def zip_to_zipstream(zip_file, only=None, exclude=None):
 
 def get_first_sheet_name(xlsx_zipfile):
     try:
-        return next(path for path in xlsx_zipfile.namelist() if path.startswith(EXCEL_WORKSHEETS_PATH))
+        return next(
+            path
+            for path in xlsx_zipfile.namelist()
+            if path.startswith(EXCEL_WORKSHEETS_PATH) and path.endswith('.xml')
+        )
     except StopIteration:
         return None


### PR DESCRIPTION
The attached Excel file (which I simply generated from a blank file with the latest version of Excel on macOS) doesn't work as a template because `get_first_sheet_name` will return `xl/worksheets/_rels/sheet1.xml.rels` instead of `xl/worksheets/sheet1.xml`.

I'm proposing a patch that seems commensurate with the current level of sophistication of `get_first_sheet_name`.

[devis-sante.xlsx](https://github.com/Polyconseil/xlsx_streaming/files/767404/devis-sante.xlsx)
