### PR TITLE
streaming: Fix bug in `stream_queryset_as_xlsx()` when used with Django QuerySet objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,12 @@
 0.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix bug in ``stream_queryset_as_xlsx()`` that was introduced in
+  version 0.4.0. When called with a Django QuerySet object (or
+  something similar), the function made a single SQL query, instead of
+  multiple SQL queries depending on the ``batch_size`` argument. This
+  bug may cause performance issues when fetching many rows from the
+  database.
 
 
 0.4.0 (2019-11-06)

--- a/xlsx_streaming/streaming.py
+++ b/xlsx_streaming/streaming.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from itertools import chain, islice
 import logging
+import types
 import zipfile
 
 import zipstream
@@ -77,15 +78,25 @@ def stream_queryset_as_xlsx(
 
     return zipped_stream
 
-def serialize_queryset_by_batch(qs, serializer, batch_size):
-    qs_slices = chunks(qs, batch_size)
-    for batch in qs_slices:
-        yield serializer(list(batch))
 
-def chunks(iterable, size):
+def serialize_queryset_by_batch(qs, serializer, batch_size):
+    if isinstance(qs, types.GeneratorType):
+        qs_slices = _chunks(qs, batch_size)
+        for batch in qs_slices:
+            yield serializer(list(batch))
+    else:
+        start, last_batch = 0, []
+        while start == 0 or len(last_batch) == batch_size:
+            last_batch = list(qs[start:start + batch_size])  # force queryset evaluation
+            yield serializer(last_batch)
+            start += batch_size
+
+
+def _chunks(iterable, size):
     iterator = iter(iterable)
     for first in iterator:
         yield chain([first], islice(iterator, size - 1))
+
 
 def zip_to_zipstream(zip_file, only=None, exclude=None):
     """


### PR DESCRIPTION
183d794aee94e1127dd20c75a (version 0.4.0) accidentally changed the
behaviour of this function in some circumstances. When given a Django
QuerySet, the queryset would be evaluated only once (thus making a
single SQL query), and batched manually by the function. This could
cause performance issues if there were many rows to fetch. The
previous behaviour (which we restore here) was to perform multiple SQL
queries, actually using the `batch_size` argument of the function.

This bug was spotted by Vincent Desprez (@vinzd).