### PR TITLE
streaming: Accept an iterator in stream_queryset_as_xlsx()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 1.0.0 (unreleased)
 ------------------
 
+- ``stream_queryset_as_xlsx()`` now accepts an iterator.
 - |backward-incompatibility| Drop support of Python 2 and Python 3.4. xlxs_streaming now supports
   only Python 3.5 and onward.
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -68,6 +68,10 @@ class TestStreaming(unittest.TestCase):
         queryset = generate()
         self._test_serialize_queryset_by_batch(queryset)
 
+    def test_serialize_queryset_by_batch_with_iterator(self):
+        queryset = iter(range(10 * i, 10 * (i + 1)) for i in range(27))
+        self._test_serialize_queryset_by_batch(queryset)
+
     def test_serialize_queryset_django_with_queryset(self):
         # Fake a Django QuerySet to make sure that we fetch database
         # results by batch, not in a single query.

--- a/xlsx_streaming/render.py
+++ b/xlsx_streaming/render.py
@@ -143,8 +143,8 @@ def _update_numeric_cell(cell, value):
             cell_text = str(value)
         try:
             float(cell_text)
-        except:
-            raise AttributeError("expected a numeric or date like value got %s." % cell_text)
+        except Exception as e:  # pylint: disable=broad-except
+            raise AttributeError("expected a numeric or date like value got %s." % cell_text) from e
     next(child for child in cell if child.tag == 'v').text = cell_text
 
 

--- a/xlsx_streaming/streaming.py
+++ b/xlsx_streaming/streaming.py
@@ -1,6 +1,6 @@
+import collections.abc
 from itertools import chain, islice
 import logging
-import types
 import zipfile
 
 import zipstream
@@ -76,7 +76,7 @@ def stream_queryset_as_xlsx(
 
 
 def serialize_queryset_by_batch(qs, serializer, batch_size):
-    if isinstance(qs, types.GeneratorType):
+    if isinstance(qs, collections.abc.Iterator):
         qs_slices = _chunks(qs, batch_size)
         for batch in qs_slices:
             yield serializer(list(batch))


### PR DESCRIPTION
`abc.collections.Iterator` accepts both generator and iterator objects, let's also accept iterators.