### PR TITLE
feat: copy sheetViews's pane from the template if present

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@
 
 - Add support for Python 3.10 & 3.11 & 3.12
 - Drop support for Python 3.6 & 3.7
+- If provided template contains ``sheetViews`` with a ``pane`` element, this
+  element will now be copied to the resulting Excel document.
 
 
 1.1.0 (2021-06-23)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -16,9 +16,10 @@ class TestOpenXML(unittest.TestCase):
         self.assertEqual(next(element_iter).tag, 'sheetPr')
         self.assertEqual(next(element_iter).tag, 'outlinePr')
 
-    def test_get_header_and_row_template(self):
-        header, template = render.get_elements_from_template(gen_xlsx_sheet())  # pylint: disable=unbalanced-tuple-unpacking
+    def test_get_elements_from_template(self):
+        header, views, template = render.get_elements_from_template(gen_xlsx_sheet())  # pylint: disable=unbalanced-tuple-unpacking
         self.assertTrue(header is None)
+        self.assertTrue(views is None)
         self.assertEqual(template.tag, 'row')
         self.assertEqual(template.get('r'), '1')
         element_iter = template.iter()
@@ -26,6 +27,20 @@ class TestOpenXML(unittest.TestCase):
         child = next(element_iter)
         self.assertEqual(child.tag, 'c')
         self.assertEqual(child.get('r'), 'A1')
+
+    def test_views_from_template(self):
+        header, views, _ = render.get_elements_from_template(
+            gen_xlsx_sheet(with_header=True, with_views=True)
+        )
+        self.assertTrue(header is not None)
+        self.assertTrue(views is not None)
+        self.assertEqual(views.tag, 'sheetViews')
+        self.assertEqual(len(views), 1)
+        self.assertEqual(len(views[0]), 1)
+        self.assertEqual(views[0][0].tag, 'pane')
+        self.assertEqual(views[0][0].get('xSplit'), None)
+        self.assertEqual(views[0][0].get('ySplit'), '1')
+        self.assertEqual(views[0][0].get('state'), 'frozen')
 
     def test_get_column(self):
         self.assertEqual(render.get_column(ETree.Element('c', r='A1')), 'A')

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -17,7 +17,7 @@ class TestOpenXML(unittest.TestCase):
         self.assertEqual(next(element_iter).tag, 'outlinePr')
 
     def test_get_header_and_row_template(self):
-        header, template = render.get_header_and_row_template(gen_xlsx_sheet())  # pylint: disable=unbalanced-tuple-unpacking
+        header, template = render.get_elements_from_template(gen_xlsx_sheet())  # pylint: disable=unbalanced-tuple-unpacking
         self.assertTrue(header is None)
         self.assertEqual(template.tag, 'row')
         self.assertEqual(template.get('r'), '1')
@@ -152,6 +152,9 @@ class TestOpenXML(unittest.TestCase):
         stream = next(xlsx_doc)
         document += stream
         self.assertTrue(stream.startswith(b'<worksheet'))
+        stream = next(xlsx_doc)
+        document += stream
+        self.assertTrue(stream.startswith(b'<sheetData'))
         stream = next(xlsx_doc)
         document += stream
         self.assertTrue(stream.startswith(b'<row'))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,7 @@ import openpyxl
 from xlsx_streaming import streaming
 
 
-def gen_xlsx_template(with_header=False):
+def gen_xlsx_template(with_header=False, with_views=False):
     wb = openpyxl.Workbook()
     rows = [[42, 'éOui>€', datetime.datetime(2012, 1, 2, 10, 10)]]
     if with_header:
@@ -16,14 +16,16 @@ def gen_xlsx_template(with_header=False):
     for i, row in enumerate(rows):
         for j, value in enumerate(row):
             wb.active.cell(row=i + 1, column=j + 1).value = value
+    if with_views:
+        wb.active.freeze_panes = "A2"
     with tempfile.NamedTemporaryFile() as fp:
         openpyxl.writer.excel.save_workbook(wb, fp)
         fp.seek(0)
         return io.BytesIO(fp.read())
 
 
-def gen_xlsx_sheet(with_header=False):
-    xlsx_template = gen_xlsx_template(with_header=with_header)
+def gen_xlsx_sheet(with_header=False, with_views=False):
+    xlsx_template = gen_xlsx_template(with_header=with_header, with_views=with_views)
     with zipfile.ZipFile(xlsx_template, mode='r') as zip_template:
         sheet_name = streaming.get_first_sheet_name(zip_template)
         return zip_template.read(sheet_name).decode('utf-8')


### PR DESCRIPTION
Hello there!

We have been using this fantastic library to generate xlsx documents from MongoDB collections. During our usage, we came across a specific feature that we believe would greatly enhance the user experience – the ability to freeze headers. As a result, I've made modifications to the codebase to include the copying of the `pane` element within the `sheetViews`, provided it's present in the template.

I have made an effort to ensure that my changes maintain the existing content and structure, but I am open to any feedback or suggestions for improvement. We are eager to see this feature incorporated into the official release.

Thank you for your time and consideration!