### PR TITLE
Escape invalid XML characters according to OOM spec

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix handling of invalid XML characters according to OOM specification
+  (e.g. ``\x02`` will be escaped as ``_x0002_``).
 
 
 2.0.0 (2024-01-15)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -143,6 +143,17 @@ class TestOpenXML(unittest.TestCase):
             '</row>'.encode()
         )
 
+    def test_render_row_invalid_xml_char(self):
+        row = render.render_row(["foo\x02bar", "_x0002_"], None, 2)
+        ETree.fromstring(row)
+        self.assertEqual(
+            row,
+            '<row r="2">'
+            '<c r="A2" t="inlineStr"><is><t>foo_x0002_bar</t></is></c>'
+            '<c r="B2" t="inlineStr"><is><t>_x005F_x0002_</t></is></c>'
+            "</row>".encode(),
+        )
+
     def test_render_rows(self):
         template_row = self.gen_row()
         rows, lines = render.render_rows([[42, 'Noé!>', 24], [18, '<éON', 21]], template_row, 1)


### PR DESCRIPTION
To avoid generating invalid Excel files that crash when opened.